### PR TITLE
modified setup-headers to cdn urls, fixes bad header issue #40

### DIFF
--- a/setup-headers.sh
+++ b/setup-headers.sh
@@ -42,7 +42,7 @@ if [ $supported -eq 0 ]; then
   exit 1
 fi
 # Adding the ppa to apt sources.
-echo "deb https://raw.githubusercontent.com/divx118/crouton-packages/$BRANCH/ $KERNEL main" > /etc/apt/sources.list.d/crouton-packages.list
+echo "deb http://cdn.rawgit.com/divx118/crouton-packages/$BRANCH/ $KERNEL main" > /etc/apt/sources.list.d/crouton-packages.list
 apt-get update
 # umount bindmounts /lib/modules from enter-chroot
 for m in `cat /proc/mounts | /usr/bin/cut -d ' ' -f2 | grep /lib/modules| grep -v "^/$" `; do
@@ -60,7 +60,7 @@ if [ -f /etc/rc.local ]; then
   echo "============================================================================"
   echo ""
 fi
-wget -O /etc/rc.local "https://raw.githubusercontent.com/divx118/crouton-packages/$BRANCH/rc.local"
+wget -O /etc/rc.local "http://cdn.rawgit.com/divx118/crouton-packages/$BRANCH/rc.local"
 chown root:root /etc/rc.local
 chmod +x /etc/rc.local
 echo ""


### PR DESCRIPTION
On some distros (Ubuntu Trusty and Debian Jessie) using apt-transport-https fails due to additional headers added by github. The solution is to serve the packages via a CDN. In this case I make use of http://rawgit.com

I've modified the repo sources to use cdn.rawgit.com, specifically the http:// version as I was getting certificate errors with the https:// version